### PR TITLE
Add get-sail to build command: Task build doesnt run due to missing vendor/bin/sail

### DIFF
--- a/taskfile.yml
+++ b/taskfile.yml
@@ -153,7 +153,7 @@ tasks:
     cmds:
       - "{{ .SAIL }} {{ .cmd }}"
 
-  get-sail:
+  composer-install:
     desc: Get Laravel Sail
     cmds:
       - test -f 'vendor/bin/sail' && echo "Sail script exists, skip" || docker run --rm

--- a/taskfile.yml
+++ b/taskfile.yml
@@ -4,11 +4,22 @@ vars:
   SAIL: ./vendor/bin/sail
 
 tasks:
+  composer-install:
+    desc: Install Composer dependencies
+    silent: true
+    cmds:
+      - test -d 'vendor' && echo "Vendor directory exists, skip" || docker run --rm
+        -u "$(id -u):$(id -g)"
+        -v "$(pwd):/var/www/html"
+        -w /var/www/html
+        laravelsail/php82-composer:latest
+        composer install --ignore-platform-reqs
+
   build:
     desc: Build Laravel Sail application image
     cmds:
       - test -f '.env' && echo "Env file exists, skip" || cp .env.example .env
-      - task: get-sail
+      - task: composer-install
       - task: run
         vars: { cmd: build --no-cache }
       - task: start
@@ -152,13 +163,3 @@ tasks:
       vars: [cmd]
     cmds:
       - "{{ .SAIL }} {{ .cmd }}"
-
-  composer-install:
-    desc: Get Laravel Sail
-    cmds:
-      - test -f 'vendor/bin/sail' && echo "Sail script exists, skip" || docker run --rm
-        -u "$(id -u):$(id -g)"
-        -v "$(pwd):/var/www/html"
-        -w /var/www/html
-        laravelsail/php84-composer:latest
-        composer install --ignore-platform-reqs

--- a/taskfile.yml
+++ b/taskfile.yml
@@ -8,6 +8,7 @@ tasks:
     desc: Build Laravel Sail application image
     cmds:
       - test -f '.env' && echo "Env file exists, skip" || cp .env.example .env
+      - task: get-sail
       - task: run
         vars: { cmd: build --no-cache }
       - task: start
@@ -151,3 +152,13 @@ tasks:
       vars: [cmd]
     cmds:
       - "{{ .SAIL }} {{ .cmd }}"
+
+  get-sail:
+    desc: Get Laravel Sail
+    cmds:
+      - test -f 'vendor/bin/sail' && echo "Sail script exists, skip" || docker run --rm
+        -u "$(id -u):$(id -g)"
+        -v "$(pwd):/var/www/html"
+        -w /var/www/html
+        laravelsail/php84-composer:latest
+        composer install --ignore-platform-reqs


### PR DESCRIPTION
Hello,

Thank you for this project. I've just tried to spin it up and when I run `task build`  I get:

```
bjt@webdev:~/project/breeze-api$ task build
task: [build] test -f '.env' && echo "Env file exists, skip" || cp .env.example .env
stat /project/breeze-api/vendor/bin/sail: no such file or directory
task: Failed to run task "build": exit status 127
```

which is due to the missing vendor directory. As as suggestion, it may be helpful to include [this](https://laravel.com/docs/11.x/sail#installing-composer-dependencies-for-existing-projects) to rectify the issue.

```
docker run --rm \
    -u "$(id -u):$(id -g)" \
    -v "$(pwd):/var/www/html" \
    -w /var/www/html \
    laravelsail/php84-composer:latest \
    composer install --ignore-platform-reqs
```

I've attempted to add it in and do a pull request. This is my first pull request, and first time using taskfile (nice find, thank you) so sorry if it's wrong!
